### PR TITLE
Bump `TikzPictures` 3.3 -> 3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Spot"
 uuid = "f11abc24-ce50-11e8-2475-af6658d13f2b"
 repo = "https://github.com/sisl/Spot.jl"
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Graphs = "1.5"
 MetaGraphs = "0.6, 0.7"
 Parameters = "0.12"
 Spot_julia_jll = "2.9.7"
-TikzPictures = "3.3"
+TikzPictures = "3.5"
 julia = "1.6, 1.7, 1.8, 1.9, 1.10"
 libcxxwrap_julia_jll = "0.12.3"
 


### PR DESCRIPTION
`TikzPictures@v3.4` fails to install on M-Series Macs (fixed in `v3.5` @ https://github.com/JuliaTeX/TikzPictures.jl/pull/84). This means that `Spot` fails to install on M-Series Macs unless you explicitly `pkg> add TikzPictures@3.3`.

This PR addresses the issue by bumping compat to `v3.5`.